### PR TITLE
Removed .vscode folder and added it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 /development/fiwl.js
 node_modules
 typing
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.tabSize": 2
-}


### PR DESCRIPTION
It is a common practice **to not** commit the `.vscode` folder to Github. It is not universal for all IDEs.

It also only contained a `settings.json` file with the following code:

```json
{
    "editor.tabSize": 2
}
```

This can **easily** be implemented with [Prettier](https://prettier.io/) which makes that config file **obsolete**.

Do we plan to integrate Prettier with this code repository?